### PR TITLE
fix disconnect button function by calling useWeb3React.deactive

### DIFF
--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -28,6 +28,7 @@ export const Wallet = () => {
     activate,
     active,
     connector,
+    deactivate
   } = useWeb3React<Web3Provider>()
 
   // [
@@ -70,6 +71,7 @@ export const Wallet = () => {
 
   const onDisconnect = () => {     
     injectedConnector.deactivate();
+    deactivate();
   }
 
   const sym = TOKENS_BY_NETWORK[Networks.Kovan][0].symbol;


### PR DESCRIPTION
By disconnect, use `useWeb3React.deactivate` rather than `InjectedConnector.deactivate`.

The call of `InjectedConnector.deactivate` is somehow kept to guarantee the event emit for further use.

 